### PR TITLE
add link to github

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -1,3 +1,5 @@
+See the [github repository](https://github.com/Materials-Consortia/OPTiMaDe) for the most up-to-date specification.
+
 # OPTIMADE API specification v0.9.5
 
 [1. Introduction](#h.1) 


### PR DESCRIPTION
donnie mentioned that he just went to optimade.org/optimade
and did not notice that what was displayed here was outdated