### PR TITLE
Adjust to consistently use relative paths

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,maximum-scale=2">
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"> {% seo %}
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision }}"> {% seo %}
     {% include head.html %}
 </head>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,9 +33,9 @@
             </div>
             <br>
             <div class="menu">
-        	<a href="/"><img src="assets/images/home.png" height="15px"></a>
-                <a href="/optimade">API Specification</a>
-                <a href="/contributors">Contributors</a>
+        	<a href="index"><img src="assets/images/home.png" height="15px"></a>
+                <a href="optimade">API Specification</a>
+                <a href="contributors">Contributors</a>
                 <a href="https://github.com/Materials-Consortia/OPTiMaDe/wiki" target="_blank">Wiki</a>
             	<a href="https://github.com/Materials-Consortia/" target="_blank">GitHub
                     <img src="assets/images/blacktocat.png" height="15px"></a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,maximum-scale=2">
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision }}"> {% seo %}
+    <link rel="stylesheet" type="text/css" media="screen" href="assets/css{{ '/style.css?v=' | append: site.github.build_revision }}"> {% seo %}
     {% include head.html %}
 </head>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,maximum-scale=2">
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"> {% seo %}
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"> {% seo %}
     {% include head.html %}
 </head>
 
@@ -33,12 +33,12 @@
             </div>
             <br>
             <div class="menu">
-        	<a href="/"><img src="/assets/images/home.png" height="15px"></a>
+        	<a href="/"><img src="assets/images/home.png" height="15px"></a>
                 <a href="/optimade">API Specification</a>
                 <a href="/contributors">Contributors</a>
                 <a href="https://github.com/Materials-Consortia/OPTiMaDe/wiki" target="_blank">Wiki</a>
             	<a href="https://github.com/Materials-Consortia/" target="_blank">GitHub
-                    <img src="/assets/images/blacktocat.png" height="15px"></a>
+                    <img src="assets/images/blacktocat.png" height="15px"></a>
        	    </div>
 
         </header>


### PR DESCRIPTION
I'm preparing to update the website for the v1.0-rc1 release.

It seems it presently use a mixture of root-based URLs `/assets/...` and purely relative paths `assets/...`. The latter are preferable here, because they make it easier to fork the repository and get the website to correctly render under your own github pages domain.
