### PR TITLE
Re-introduce gap after API Documentation button

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,8 +35,7 @@
             <div class="menu">
         	<a href="index"><img src="/assets/images/home.png" height="15px"></a>
                 <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/v1.0.0-rc.1/schemas/openapi_schema.json" target="_blank">API Documentation
-                    <img src="/assets/images/swagger.png" height="15px">
-                </a>
+                    <img src="/assets/images/swagger.png" height="15px"></a>
                 <a href="optimade">API Specification</a>
                 <a href="contributors">Contributors</a>
             	<a href="https://github.com/Materials-Consortia/" target="_blank">GitHub


### PR DESCRIPTION
@ltalirz was a little too fast merging #10, this PR also fixes the gap after the API Documentation button.

This should be the final work - should have added this to the original fix PR, sorry.