### PR TITLE
OPTiMaDe -> OPTIMADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OPTiMaDe Web Site
+# OPTIMADE Web Site
 
-This folder contains the source code for the [OPTiMaDe website](http://www.optimade.org).
+This folder contains the source code for the [OPTIMADE website](http://www.optimade.org).
 
 ## Local testing
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
             <br>
             <div class="menu">
         	<a href="index"><img src="/assets/images/home.png" height="15px"></a>
-                <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/v1.0.0-rc.1/schemas/openapi_schema.json" target="_blank">API Documentation
+                <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/v1.0.0-rc.1/schemas/openapi_schema.json" target="_blank">API Documentation
                     <img src="/assets/images/swagger.png" height="15px"></a>
                 <a href="optimade">API Specification</a>
                 <a href="contributors">Contributors</a>

--- a/contributors.md
+++ b/contributors.md
@@ -1,6 +1,6 @@
 # Contributors
 
-The initial release of the OPTiMaDe API was developed by the participants of the workshops "Open Databases Integration for Materials Design"
+The initial release of the OPTIMADE API was developed by the participants of the workshops "Open Databases Integration for Materials Design"
 ([1](http://www.lorentzcenter.nl/lc/web/2016/826/info.php3?wsid=826&venue=Snellius){:target="_blank"},[2](http://www.cecam.org/workshop-1525.html){:target="_blank"})
 held at:
 

--- a/index.md
+++ b/index.md
@@ -22,6 +22,6 @@ existing and hypothetical materials, many of which have appeared online:
 - [the Data Catalyst Genome](http://suncat.stanford.edu/)
 - ...
 
-The **Open Databases Integration for Materials Design** (OPTiMaDe) consortium
+The **Open Databases Integration for Materials Design** (OPTIMADE) consortium
 aims to make materials databases interoperational by developing a common REST API.
 

--- a/optimade.md
+++ b/optimade.md
@@ -1,7 +1,7 @@
-# OPTiMaDe API Specification
+# OPTIMADE API Specification
 
-**The latest _stable_ version** is found in the [master](https://github.com/Materials-Consortia/OPTiMaDe/tree/master/optimade.md){:target="_blank"} branch in the GitHub repository.  
-**The latest _development_ version** is found in the [develop](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop/optimade.md){:target="_blank"} branch of the same repository.
+**The latest _stable_ version** is found in the [master](https://github.com/Materials-Consortia/OPTIMADE/tree/master/optimade.md){:target="_blank"} branch in the GitHub repository.  
+**The latest _development_ version** is found in the [develop](https://github.com/Materials-Consortia/OPTIMADE/tree/develop/optimade.md){:target="_blank"} branch of the same repository.
 
 If you are a **server** developer, it is _recommended_ to always implement the latest stable version.
 It is also _recommended_ to implement the latest version in development.


### PR DESCRIPTION
Correcting the capitalization of OPTIMADE as per Materials-Consortia/OPTIMADE/issues/193.