### PR TITLE
Revert "Serve both with *www* and without *www*"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-optimade.org
+www.optimade.org


### PR DESCRIPTION
PR #19 has broken our website. At least for me, HTTP requests are now responded to with "unable to resolve host address ‘optimade.org’"

We cannot just swap out www.optimade.org for optimade.org in the CNAME file unless the DNS is setup accordingly.

Also, that isn't trivial to do, since one cannot CNAME a bare domain. This requires "CNAME flattening" or similar support by those handling DNS.

As long as we don't host on a stable IP, a better strategy is likely to setup a redirect optimade.org -> www.optimade.org.