### PR TITLE
Link to latest stable docs, rather than rc.1

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
             <br>
             <div class="menu">
         	<a href="index">About</a>
-                <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/v1.0.0-rc.1/schemas/openapi_schema.json" target="_blank">Documentation</a>
+                <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/master/schemas/openapi_schema.json" target="_blank">Documentation</a>
                 <a href="optimade">Specification</a>
                 <a href="contributors">Contributors</a>
                 <a href="https://github.com/Materials-Consortia/OPTiMaDe/wiki" target="_blank">Wiki</a>


### PR DESCRIPTION
`master` of the specification repo should always point to the version we want to serve here, as far as I can tell!