### PR TITLE
Use consistent fonts for menu items and text

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,6 +2,11 @@
 ---
 
 @import "{{ site.theme }}";
+
+body, h1, h2, h3, h4, h5, h6 {
+  font-family: Arial, Helvetica, Roboto, sans-serif;
+}
+
 img {
   position: relative;
   vertical-align: middle;
@@ -41,7 +46,6 @@ img {
   display: inline-flex;
   flex-direction: row-reverse;
   flex-wrap: nowrap;
-  font-family: Overpass,sans-serif;
   font-size: 15px;
   font-weight: 700;
   justify-content: center;


### PR DESCRIPTION
Remove unimported Overpass font and fallback to sensible defaults. Closes #22.

I can't locally replicate @rartino's issue with the vertical justification of menu items, if it messes up when this is merged then I can make another PR to fix it.