### PR TITLE
Add MatSci Forum to main page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,7 @@
                 <a href="contributors">Contributors</a>
                 <a href="https://github.com/Materials-Consortia/OPTiMaDe/wiki" target="_blank">Wiki</a>
             	<a href="https://github.com/Materials-Consortia/" target="_blank">GitHub</a>
+            	<a href="https://matsci.org/c/optimade/" target="_blank">Forum</a>
        	    </div>
 
         </header>


### PR DESCRIPTION
Adds a link to the MatSci forum for OPTIMADE into the header bar