### PR TITLE
Updated authors, created dedicated documentation page

### DIFF
--- a/_includes/AUTHORS
+++ b/_includes/AUTHORS
@@ -1,0 +1,57 @@
+The OPTIMADE development team in alphabetical order:
+
+- Casper Andersen
+- Thomas Archer
+- Rickard Armiento
+- Rossella Aversa
+- Evgeny Blokhin
+- Gareth Conduit
+- Davide Di Stefano
+- Alexander Dorsk
+- Claudia Draxl
+- Shyam Dwaraknath
+- Suleyman Er
+- Matthew Evans
+- Adam Fekete
+- Marco Fornari
+- Matteo Giantomassi
+- Abhijith Gopakumar
+- Marco Govoni
+- Saulius Gražulis
+- Geoffroy Hautier
+- Vinay Hegde
+- Matthew Horton
+- Patrick Huck
+- Georg Huhs
+- Jens Hummelshoej
+- Karsten W. Jacobsen
+- Ankit Kariryaa
+- Boris Kozinsky
+- Snehal Kumbhar
+- Mohan Liu
+- Nicola Marzari
+- Andrius Merkys
+- Fawzi Mohamed
+- Andrew Morris
+- Arash Mostofi
+- Nicolas Mounet
+- Corey Oses
+- Guido Petretto
+- Giovanni Pizzi
+- Thomas Purcell
+- Francesco Ricci
+- Gian-Marco Rignanese
+- Matthias Scheffler
+- Markus Scheidgen
+- Daniel Speckhard
+- Leopold Talirz
+- Cormac Toher
+- Daniele Tomerini
+- Martin Uhrin
+- Pierre Villars
+- David Waroquiers
+- Donald Winston
+- Chris Wolverton
+- Michael Wu
+- Yibin Xu
+- Xiaoyu Yang

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,13 +20,12 @@
             </div>
             <br>
             <div class="menu">
-        	<a href="index">About</a>
-                <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/master/schemas/openapi_schema.json" target="_blank">Documentation</a>
+                <a href="index">About</a>
+                <a href="documentation">Documentation</a>
                 <a href="optimade">Specification</a>
                 <a href="contributors">Contributors</a>
-                <a href="https://github.com/Materials-Consortia/OPTiMaDe/wiki" target="_blank">Wiki</a>
-            	<a href="https://github.com/Materials-Consortia/" target="_blank">GitHub</a>
-            	<a href="https://matsci.org/c/optimade/" target="_blank">Forum</a>
+            	  <a href="https://github.com/Materials-Consortia/" target="_blank">GitHub</a>
+              	<a href="https://matsci.org/c/optimade/" target="_blank">Forum</a>
        	    </div>
 
         </header>

--- a/contributors.md
+++ b/contributors.md
@@ -1,63 +1,10 @@
 # Contributors
 
-The initial release of the OPTIMADE API was developed by the participants of the workshops "Open Databases Integration for Materials Design"
-([1](http://www.lorentzcenter.nl/lc/web/2016/826/info.php3?wsid=826&venue=Snellius){:target="_blank"},[2](http://www.cecam.org/workshop-1525.html){:target="_blank"})
-held at:
+The initial release of the OPTIMADE API was developed by the participants of the workshops "Open Databases Integration for Materials Design" held at:
 
 - the Lorentz Center in Leiden, Netherlands from 2016-10-24 to 2016-10-28
-- the CECAM in Lausanne, Switzerland from 2018-06-11 to 2018-06-15
-- the CECAM in Lausanne, Switzerland from 2019-06-11 to 2019-06-14
+- the CECAM in Lausanne, Switzerland from 2018-06-11 to 2018-06-15 ([CECAM Flagship Workshop 244](https://www.cecam.org/workshop-details/244))
+- the CECAM in Lausanne, Switzerland from 2019-06-11 to 2019-06-14 ([CECAM Flagship Workshop 154](https://www.cecam.org/workshop-details/154))
+- virtually, supported by CECAM in Lausanne, Switzerland from 2020-06-08 to 2020-06-12 ([CECAM Flagship Workshop 991](https://www.cecam.org/workshop-details/991))
 
-In alphabetical order:
-
-- Casper Andersen
-- Thomas Archer
-- Rickard Armiento
-- Rossella Aversa
-- Evgeny Blokhin
-- Gareth Conduit
-- Davide Di Stefano
-- Alexander Dorsk
-- Claudia Draxl
-- Shyam Dwaraknath
-- Suleyman Er
-- Matthew Evans
-- Adam Fekete
-- Marco Fornari
-- Matteo Giantomassi
-- Abhijith Gopakumar
-- Marco Govoni
-- Saulius Gražulis
-- Geoffroy Hautier
-- Vinay Hedge
-- Georg Huhs
-- Jens Hummelshoej
-- Karsten W. Jacobsen
-- Ankit Kariryaa
-- Boris Kozinsky
-- Snehal Kumbhar
-- Nicola Marzari
-- Andrius Merkys
-- Fawzi Mohamed
-- Andrew Morris
-- Arash Mostofi
-- Nicolas Mounet
-- Corey Oses
-- Guido Petretto
-- Thomas Purcell
-- Giovanni Pizzi
-- Francesco Ricci
-- Gian-Marco Rignanese
-- Matthias Scheffler
-- Markus Scheidgen
-- Daniel Speckhard
-- Leopold Talirz
-- Cormac Toher
-- Daniele Tomerini
-- Martin Uhrin
-- Pierre Villars
-- David Waroquiers
-- Donald Winston
-- Chris Wolverton
-- Yibin Xu
-- Xiaoyu Yang
+{ include AUTHORS }

--- a/contributors.md
+++ b/contributors.md
@@ -7,4 +7,4 @@ The initial release of the OPTIMADE API was developed by the participants of the
 - the CECAM in Lausanne, Switzerland from 2019-06-11 to 2019-06-14 ([CECAM Flagship Workshop 154](https://www.cecam.org/workshop-details/154))
 - virtually, supported by CECAM in Lausanne, Switzerland from 2020-06-08 to 2020-06-12 ([CECAM Flagship Workshop 991](https://www.cecam.org/workshop-details/991))
 
-{ include AUTHORS }
+{% include AUTHORS %}

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,4 @@
+- [Stable API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/master/schemas/openapi_schema.json)
+- [Development API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/develop/schemas/openapi_schema.json)
+- [`optimade-python-tools` documentation](https://optimade.org/optimade-python-tools)
+- [OPTIMADE wiki on GitHub](https://github.com/Materials-Consortia/OPTIMADE/wiki)


### PR DESCRIPTION
This is a quick PR that updates the AUTHORS list (making it easier to just copy from the specification repo) and adds a documentation page with more links (and moves the banner-level Wiki link into this new page). Also added some CECAM links to the individual workshops, and removed the dead Leiden Centre link.

We could consider adding the specification as a submodule to get the latest AUTHORS but it doesn't seem worth it to me.