### PR TITLE
Minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OPTIMADE Web Site
 
-This folder contains the source code for the [OPTIMADE website](http://www.optimade.org).
+This folder contains the source code for the [OPTIMADE website](https://www.optimade.org).
 
 ## Local testing
 

--- a/_includes/next_meeting.html
+++ b/_includes/next_meeting.html
@@ -1,2 +1,1 @@
-[Friday April 23rd at 15:00
-UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210420T15){:target=_blank}
+[Friday April 23rd at 15:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210420T15){:target=_blank}

--- a/_includes/next_meeting.html
+++ b/_includes/next_meeting.html
@@ -1,1 +1,1 @@
-[Friday April 23rd at 15:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210420T15){:target=_blank}
+[Friday April 23rd at 15:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210420T15){:target="_blank"}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
         <header class="inner">
 
             <div id="logo">
-              <img src="assets/images/optimade-text-right-transparent-bg.png">
+              <a href="index"><img src="assets/images/optimade-text-right-transparent-bg.png"></a>
             </div>
             <br>
             <div class="menu">

--- a/clients.md
+++ b/clients.md
@@ -4,26 +4,26 @@ There are already a few ways to try out OPTIMADE implementations:
 
 ## Swagger
 
-Through the [Swagger/OpenAPI UI](https://petstore.swagger.io){:target=_blank}, one can try making queries to implementations hosting an OpenAPI specification.
-Implementations based on the Python [`optimade`](https://pypi.org/project/optimade/){:target=_blank} package from the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools){:target=_blank} repository automatically creates and hosts an OpenAPI specification at `/extensions/openapi.json`.
+Through the [Swagger/OpenAPI UI](https://petstore.swagger.io){:target="_blank"}, one can try making queries to implementations hosting an OpenAPI specification.
+Implementations based on the Python [`optimade`](https://pypi.org/project/optimade/){:target="_blank"} package from the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools){:target="_blank"} repository automatically creates and hosts an OpenAPI specification at `/extensions/openapi.json`.
 Note, this is the default location and may not be where the OpenAPI specification is found for individual implementations.
 
 **Try this**:
 
-- [Open Database of Crystals (ODBX)](https://petstore.swagger.io/?url=https://optimade.odbx.science/v1/extensions/openapi.json){:target=_blank}
+- [Open Database of Crystals (ODBX)](https://petstore.swagger.io/?url=https://optimade.odbx.science/v1/extensions/openapi.json){:target="_blank"}
 
 ## Materials Cloud Tool
 
-An [open-source](https://github.com/CasperWA/voila-optimade-client){:target=_blank} web and local executable client developed by [Casper W. Andersen (THEOS, EPFL)](https://casper.welzel.nu){:target=_blank} using [Voilà](https://voila.readthedocs.io){:target=_blank} is available on [Materials Cloud](https://materialscloud.org){:target=_blank}.
-It allows for searching through OPTIMADE databases, filtering on the structure property fields defined in the [OPTIMADE API specification](optimade), and inspect and download found structures in various file formats (CIF, PDB, VASP POSCAR, XYZ, Quantum ESPRESSO input, and more) utilizing the adapters from the Python [`optimade`](https://pypi.org/project/optimade/){:target=_blank} package in the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools){:target=_blank} repository.
+An [open-source](https://github.com/CasperWA/voila-optimade-client){:target="_blank"} web and local executable client developed by [Casper W. Andersen (THEOS, EPFL)](https://casper.welzel.nu){:target="_blank"} using [Voilà](https://voila.readthedocs.io){:target="_blank"} is available on [Materials Cloud](https://materialscloud.org){:target="_blank"}.
+It allows for searching through OPTIMADE databases, filtering on the structure property fields defined in the [OPTIMADE API specification](optimade), and inspect and download found structures in various file formats (CIF, PDB, VASP POSCAR, XYZ, Quantum ESPRESSO input, and more) utilizing the adapters from the Python [`optimade`](https://pypi.org/project/optimade/){:target="_blank"} package in the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools){:target="_blank"} repository.
 
 The filtering can be done either using the OPTIMADE filter language (see the specification for more information) directly, or one can use the friendly filtering widgets (default).
 
-**Try this**: [materialscloud.org/optimadeclient](https://materialscloud.org/optimadeclient){:target=_blank}
+**Try this**: [materialscloud.org/optimadeclient](https://materialscloud.org/optimadeclient){:target="_blank"}
 
 ## optimade.science
 
-An [open-source](https://github.com/tilde-lab/optimade.science){:target=_blank} web client developed by [Evgeny Blokhin](https://tilde.pro){:target=_blank} utilizing [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){:target=_blank} is available.
+An [open-source](https://github.com/tilde-lab/optimade.science){:target="_blank"} web client developed by [Evgeny Blokhin](https://tilde.pro){:target="_blank"} utilizing [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){:target="_blank"} is available.
 It allows for searching through *multiple* OPTIMADE databases using the OPTIMADE filter language (see the specification for more information) and the power of CORS.
 
-**Try this**: [optimade.science](https://optimade.science){:target=_blank}
+**Try this**: [optimade.science](https://optimade.science){:target="_blank"}

--- a/contributors.md
+++ b/contributors.md
@@ -3,8 +3,8 @@
 The initial release of the OPTIMADE API was developed by the participants of the workshops "Open Databases Integration for Materials Design" held at:
 
 - the Lorentz Center in Leiden, Netherlands from 2016-10-24 to 2016-10-28
-- the CECAM in Lausanne, Switzerland from 2018-06-11 to 2018-06-15 ([CECAM Flagship Workshop 244](https://www.cecam.org/workshop-details/244))
-- the CECAM in Lausanne, Switzerland from 2019-06-11 to 2019-06-14 ([CECAM Flagship Workshop 154](https://www.cecam.org/workshop-details/154))
-- virtually, supported by CECAM in Lausanne, Switzerland from 2020-06-08 to 2020-06-12 ([CECAM Flagship Workshop 991](https://www.cecam.org/workshop-details/991))
+- the CECAM in Lausanne, Switzerland from 2018-06-11 to 2018-06-15 ([CECAM Flagship Workshop 244](https://www.cecam.org/workshop-details/244){:target="_blank"})
+- the CECAM in Lausanne, Switzerland from 2019-06-11 to 2019-06-14 ([CECAM Flagship Workshop 154](https://www.cecam.org/workshop-details/154){:target="_blank"})
+- virtually, supported by CECAM in Lausanne, Switzerland from 2020-06-08 to 2020-06-12 ([CECAM Flagship Workshop 991](https://www.cecam.org/workshop-details/991){:target="_blank"})
 
 {% include AUTHORS %}

--- a/documentation.md
+++ b/documentation.md
@@ -1,7 +1,7 @@
 # Documentation
 
-- **[v1.0.0 API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/v1.0.0/schemas/openapi_schema.json)**
-- [Current stable API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/master/schemas/openapi_schema.json)
-- [Development API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/develop/schemas/openapi_schema.json)
-- [`optimade-python-tools` documentation](https://optimade.org/optimade-python-tools)
-- [OPTIMADE wiki on GitHub](https://github.com/Materials-Consortia/OPTIMADE/wiki)
+- **[v1.0.0 API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/v1.0.0/schemas/openapi_schema.json){:target="_blank"}**
+- [Current stable API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/master/schemas/openapi_schema.json){:target="_blank"}
+- [Development API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/develop/schemas/openapi_schema.json){:target="_blank"}
+- [`optimade-python-tools` documentation](https://optimade.org/optimade-python-tools){:target="_blank"}
+- [OPTIMADE wiki on GitHub](https://github.com/Materials-Consortia/OPTIMADE/wiki){:target="_blank"}

--- a/documentation.md
+++ b/documentation.md
@@ -1,4 +1,7 @@
-- [Stable API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/master/schemas/openapi_schema.json)
+# Documentation
+
+- **[v1.0.0 API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/v1.0.0/schemas/openapi_schema.json)**
+- [Current stable API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/master/schemas/openapi_schema.json)
 - [Development API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/develop/schemas/openapi_schema.json)
 - [`optimade-python-tools` documentation](https://optimade.org/optimade-python-tools)
 - [OPTIMADE wiki on GitHub](https://github.com/Materials-Consortia/OPTIMADE/wiki)

--- a/index.md
+++ b/index.md
@@ -18,23 +18,23 @@ This is the burgeoning area of high-throughput ab initio computation.
 Such calculations have been used to create large databases containing the calculated properties of existing and hypothetical materials, many of which have appeared online.
 
 We have released version 1.0 of the OPTIMADE specification, with several databases already providing implementations.
-A full list is available on the [OPTIMADE providers dashboard](https://www.optimade.org/providers-dashboard/).
+A full list is available on the [OPTIMADE providers dashboard](https://www.optimade.org/providers-dashboard/){:target="_blank"}.
 
 ## How to cite OPTIMADE
 
 Should you wish to cite the OPTIMADE specification, please use the following:
 
-- Andersen *et al*, OPTIMADE: an API for exchanging materials data (2021) [arXiv:2103.02068](https://arxiv.org/abs/2103.02068){:target=_blank}
-- Andersen *et al*, The OPTIMADE Specification, [10.5281/zenodo.4195050](https://doi.org/10.5281/zenodo.4195050){:target=_blank}
+- Andersen *et al*, OPTIMADE: an API for exchanging materials data (2021) [arXiv:2103.02068](https://arxiv.org/abs/2103.02068){:target="_blank"}
+- Andersen *et al*, The OPTIMADE Specification, [10.5281/zenodo.4195050](https://doi.org/10.5281/zenodo.4195050){:target="_blank"}
 
 ## Get involved
 
-All of our work is openly available under the [Materials-Consortia](https://github.com/Materials-Consortia/) organization on GitHub and welcome all contributions.
+All of our work is openly available under the [Materials-Consortia](https://github.com/Materials-Consortia/){:target="_blank"} organization on GitHub and welcome all contributions.
 
 We would love to help you create and register your own OPTIMADE API implementations and hear your feedback on the specification.
 We meet monthly in the "OPTIMADE" room on Jitsi; everyone is welcome to join the discussion, please feel free to reach out on the mailing list
 `dev[at]optimade.org` to register your interest.
 The next meeting will take place on {% include {{ page.next_meeting }} %}.
 
-With the support of [CECAM](www.cecam.org){:target=_blank}, we hold [annual workshops](https://www.cecam.org/search#stq=%22Open%20Databases%20Integration%20for%20Materials%20Design%22&stp=1){:target=_blank} to discuss and develop the specification and related ideas.
+With the support of [CECAM](www.cecam.org){:target="_blank"}, we hold [annual workshops](https://www.cecam.org/search#stq=%22Open%20Databases%20Integration%20for%20Materials%20Design%22&stp=1){:target="_blank"} to discuss and develop the specification and related ideas.
 The 2021 workshop will be held virtually and the announcement will appear on the CECAM website soon.

--- a/index.md
+++ b/index.md
@@ -5,27 +5,20 @@ next_meeting: next_meeting.html
 
 # About us
 
-The **Open Databases Integration for Materials Design** (OPTIMADE) consortium
-aims to make materials databases interoperable by developing a specification
-for a common REST API.
+The **Open Databases Integration for Materials Design** (OPTIMADE) consortium aims to make materials databases interoperable by developing a specification for a common REST API.
 
 ## Motivation
 
-Designing new materials suitable for specific applications is a long,
-complex, and costly process. Researchers think of new ideas based on
-intuition and experience. Their synthesis and evaluation require a
-tremendous amount of trial and error. In the last few years, there has
-been a major game change in materials design. Thanks to the exponential
-growth of computer power and the development of robust first-principles
-electronic structure codes, it has become possible to perform large sets
-of calculations automatically. This is the burgeoning area of
-high-throughput ab initio computation. Such calculations have been used
-to create large databases containing the calculated properties of
-existing and hypothetical materials, many of which have appeared online.
+Designing new materials suitable for specific applications is a long, complex, and costly process.
+Researchers think of new ideas based on intuition and experience.
+Their synthesis and evaluation require a tremendous amount of trial and error.
+In the last few years, there has been a major game change in materials design.
+Thanks to the exponential growth of computer power and the development of robust first-principles electronic structure codes, it has become possible to perform large sets of calculations automatically.
+This is the burgeoning area of high-throughput ab initio computation.
+Such calculations have been used to create large databases containing the calculated properties of existing and hypothetical materials, many of which have appeared online.
 
-We have released version 1.0 of the OPTIMADE specification, with several
-databases already providing implementations. A full list is available on
-the [OPTIMADE providers dashboard](https://www.optimade.org/providers-dashboard/).
+We have released version 1.0 of the OPTIMADE specification, with several databases already providing implementations.
+A full list is available on the [OPTIMADE providers dashboard](https://www.optimade.org/providers-dashboard/).
 
 ## How to cite OPTIMADE
 
@@ -36,20 +29,12 @@ Should you wish to cite the OPTIMADE specification, please use the following:
 
 ## Get involved
 
-All of our work is openly available under the
-[Materials-Consortia](https://github.com/Materials-Consortia/) organization on
-GitHub and welcome all contributions.
+All of our work is openly available under the [Materials-Consortia](https://github.com/Materials-Consortia/) organization on GitHub and welcome all contributions.
 
-We would love to help you create and register your own OPTIMADE API
-implementations and hear your feedback on the specification.
-We meet monthly in the "OPTIMADE" room on Jitsi; everyone is welcome to
-join the discussion, please feel free to reach out on the mailing list
+We would love to help you create and register your own OPTIMADE API implementations and hear your feedback on the specification.
+We meet monthly in the "OPTIMADE" room on Jitsi; everyone is welcome to join the discussion, please feel free to reach out on the mailing list
 `dev[at]optimade.org` to register your interest.
 The next meeting will take place on {% include {{ page.next_meeting }} %}.
 
-
-With the support of [CECAM](www.cecam.org){:target=_blank}, we hold 
-[annual workshops](https://www.cecam.org/search#stq=%22Open%20Databases%20Integration%20for%20Materials%20Design%22&stp=1){:target=_blank}
-to discuss and develop the specification and related ideas.
-The 2021 workshop will be held virtually and the announcement will appear
-on the CECAM website soon.
+With the support of [CECAM](www.cecam.org){:target=_blank}, we hold [annual workshops](https://www.cecam.org/search#stq=%22Open%20Databases%20Integration%20for%20Materials%20Design%22&stp=1){:target=_blank} to discuss and develop the specification and related ideas.
+The 2021 workshop will be held virtually and the announcement will appear on the CECAM website soon.

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ Should you wish to cite the OPTIMADE specification, please use the following:
 
 ## Get involved
 
-All of our work is openly available under the [Materials-Consortia](https://github.com/Materials-Consortia/){:target="_blank"} organization on GitHub and welcome all contributions.
+All of our work is openly available under the [Materials-Consortia](https://github.com/Materials-Consortia/){:target="_blank"} organization on GitHub and we welcome all contributions.
 
 We would love to help you create and register your own OPTIMADE API implementations and hear your feedback on the specification.
 We meet monthly in the "OPTIMADE" room on Jitsi; everyone is welcome to join the discussion, please feel free to reach out on the mailing list

--- a/optimade.md
+++ b/optimade.md
@@ -1,12 +1,12 @@
 # OPTIMADE API Specification
 
-**The latest _stable_ version** is found in the [master](https://github.com/Materials-Consortia/OPTIMADE/tree/master/optimade.rst){:target="_blank"} branch in the GitHub repository.  
-**The latest _development_ version** is found in the [develop](https://github.com/Materials-Consortia/OPTIMADE/tree/develop/optimade.rst){:target="_blank"} branch of the same repository.
+**The latest *stable* version** is found in the [master](https://github.com/Materials-Consortia/OPTIMADE/tree/master/optimade.rst){:target="_blank"} branch in the GitHub repository.  
+**The latest *development* version** is found in the [develop](https://github.com/Materials-Consortia/OPTIMADE/tree/develop/optimade.rst){:target="_blank"} branch of the same repository.
 
-If you are a **server** developer, it is _recommended_ to always implement the latest stable version.
-It is also _recommended_ to implement the latest version in development.
-When implementing a development version, it is _recommended_ to label it as such using the `-develop` suffix (e.g., `v0.10.1-develop`).
-You may want to use the same _master_ and _develop_ branch model employed here.
+If you are a **server** developer, it is *recommended* to always implement the latest stable version.
+It is also *recommended* to implement the latest version in development.
+When implementing a development version, it is *recommended* to label it as such using the `-develop` suffix (e.g., `v0.10.1-develop`).
+You may want to use the same *master* and *develop* branch model employed here.
 
-If you are a **client** developer, it is _recommended_ to support the latest stable version, while you are _encouraged_ to support the latest version in development.
-You may want to use the same _master_ and _develop_ branch model employed here.
+If you are a **client** developer, it is *recommended* to support the latest stable version, while you are *encouraged* to support the latest version in development.
+You may want to use the same *master* and *develop* branch model employed here.


### PR DESCRIPTION
Some minor updates to the files and the pages.

#### Visual/UX changes
- Add citing header on index (About) page (45d930b).
- Add extra documentation link (in bold) pointing to Swagger/OpenAPI using v1.0.0 of the specification (4d86df4).
- Add a header to the Documentation page (4d86df4).
- Logo links to index (About) page (1a5b41c).
- All external links (in MarkDown files) has the `target` attribute set to `"_blank"`, opening them in a new tab (295dcb8).

#### Development changes
- One sentence per line philosophy implemented for the index (About) page (45d930b).
- Use HTTPS for the link to the webpage in the README, and fix some MarkDown syntax/linting (de1cbf8).