### PR TITLE
Add clients page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
                 <a href="contributors">Contributors</a>
                 <a href="https://github.com/Materials-Consortia/" target="_blank">GitHub</a>
                 <a href="https://matsci.org/c/optimade/" target="_blank">Forum</a>
-                <a href="clients">Try It!</a>
+                <span class="special_menu"><a href="clients">Try It!</a></span>
        	    </div>
 
         </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,8 +24,9 @@
                 <a href="documentation">Documentation</a>
                 <a href="optimade">Specification</a>
                 <a href="contributors">Contributors</a>
-            	  <a href="https://github.com/Materials-Consortia/" target="_blank">GitHub</a>
-              	<a href="https://matsci.org/c/optimade/" target="_blank">Forum</a>
+                <a href="https://github.com/Materials-Consortia/" target="_blank">GitHub</a>
+                <a href="https://matsci.org/c/optimade/" target="_blank">Forum</a>
+                <a href="clients">Try It!</a>
        	    </div>
 
         </header>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -65,6 +65,18 @@ img {
     background-color: #e75254;
     border: 2px solid #e75254;
 }
+
+.menu .special_menu a {
+    background-color: #00acd9;
+    border: 2px solid #00acd9;
+    display: inline-flex;
+}
+
+.menu .special_menu a:hover {
+    background-color: #e75254;
+    border: 2px solid #e75254;
+}
+
 #logo img {
     max-width: 640px;
     width: 100%;

--- a/clients.md
+++ b/clients.md
@@ -1,0 +1,31 @@
+# Clients
+
+There are already a few ways to try out OPTIMADE implementations:
+
+## Swagger
+
+Through the [Swagger/OpenAPI UI](https://petstore.swagger.io){:target=_blank}, one can try making queries to implementations hosting an OpenAPI specification.
+Implementations based on the Python [`optimade`](https://pypi.org/project/optimade/){:target=_blank} package from the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools){:target=_blank} repository automatically creates and hosts an OpenAPI specification at `/extensions/openapi.json`.
+Note, this is the default location and may not be where the OpenAPI specification is found for individual implementations.
+
+**Try this**:
+
+- [Open Database of Crystals (ODBX)](https://petstore.swagger.io/?url=https://optimade.odbx.science/v1/extensions/openapi.json){:target=_blank}
+- [The Materials Project](https://petstore.swagger.io/?url=https://optimade.materialsproject.org/v1/extensions/openapi.json){:target=_blank}
+- [MaterialsCloud (sample DB)](https://petstore.swagger.io/?url=https://aiida-dev.materialscloud.org/optimade-sample/optimade/v1/extensions/openapi.json){:target=_blank}
+
+## MaterialsCloud Tool
+
+An [open-source](https://github.com/CasperWA/voila-optimade-client){target=_blank} web and local executable client developed by [Casper W. Andersen (THEOS, EPFL)](https://casper.welzel.nu){target=_blank} using [Voilà](https://voila.readthedocs.io){:target=_blank} is available on [MaterialsCloud](https://materialscloud.org){:target=_blank}.
+It allows for searching through OPTIMADE databases, filtering on the structure property fields defined in the [OPTIMADE API specification](optimade), and inspect and download found structures in various file formats (CIF, PDB, VASP POSCAR, XYZ, Quantum ESPRESSO input, and more) utilizing the adapters from the Python [`optimade`](https://pypi.org/project/optimade/){:target=_blank} package in the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools){:target=_blank} repository.
+
+The filtering can be done either using the OPTIMADE filter language (see the specification for more information) directly, or one can use the friendly filtering widgets (default).
+
+**Try this**: [materialscloud.org/optimadeclient](https://materialscloud.org/optimadeclient){:target=_blank}
+
+## optimade.science
+
+An [open-source](https://github.com/tilde-lab/optimade.science){:target=_blank} web client developed by [Evgeny Blokhin](https://tilde.pro){:target=_blank} utilizing [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){:target=_blank} is available.
+It allows for searching through _multiple_ OPTIMADE databases using the OPTIMADE filter language (see the specification for more information) and the power of CORS.
+
+**Try this**: [optimade.science](https://optimade.science){:target=_blank}

--- a/clients.md
+++ b/clients.md
@@ -22,10 +22,3 @@ It allows for searching through OPTIMADE databases, filtering on the structure p
 The filtering can be done either using the OPTIMADE filter language (see the specification for more information) directly, or one can use the friendly filtering widgets (default).
 
 **Try this**: [materialscloud.org/optimadeclient](https://materialscloud.org/optimadeclient){:target=_blank}
-
-## optimade.science
-
-An [open-source](https://github.com/tilde-lab/optimade.science){:target=_blank} web client developed by [Evgeny Blokhin](https://tilde.pro){:target=_blank} utilizing [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){:target=_blank} is available.
-It allows for searching through _multiple_ OPTIMADE databases using the OPTIMADE filter language (see the specification for more information) and the power of CORS.
-
-**Try this**: [optimade.science](https://optimade.science){:target=_blank}

--- a/clients.md
+++ b/clients.md
@@ -22,3 +22,10 @@ It allows for searching through OPTIMADE databases, filtering on the structure p
 The filtering can be done either using the OPTIMADE filter language (see the specification for more information) directly, or one can use the friendly filtering widgets (default).
 
 **Try this**: [materialscloud.org/optimadeclient](https://materialscloud.org/optimadeclient){:target=_blank}
+
+## optimade.science
+
+An [open-source](https://github.com/tilde-lab/optimade.science){:target=_blank} web client developed by [Evgeny Blokhin](https://tilde.pro){:target=_blank} utilizing [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS){:target=_blank} is available.
+It allows for searching through _multiple_ OPTIMADE databases using the OPTIMADE filter language (see the specification for more information) and the power of CORS.
+
+**Try this**: [optimade.science](https://optimade.science){:target=_blank}

--- a/clients.md
+++ b/clients.md
@@ -16,7 +16,7 @@ Note, this is the default location and may not be where the OpenAPI specificatio
 
 ## MaterialsCloud Tool
 
-An [open-source](https://github.com/CasperWA/voila-optimade-client){target=_blank} web and local executable client developed by [Casper W. Andersen (THEOS, EPFL)](https://casper.welzel.nu){target=_blank} using [Voilà](https://voila.readthedocs.io){:target=_blank} is available on [MaterialsCloud](https://materialscloud.org){:target=_blank}.
+An [open-source](https://github.com/CasperWA/voila-optimade-client){:target=_blank} web and local executable client developed by [Casper W. Andersen (THEOS, EPFL)](https://casper.welzel.nu){:target=_blank} using [Voilà](https://voila.readthedocs.io){:target=_blank} is available on [MaterialsCloud](https://materialscloud.org){:target=_blank}.
 It allows for searching through OPTIMADE databases, filtering on the structure property fields defined in the [OPTIMADE API specification](optimade), and inspect and download found structures in various file formats (CIF, PDB, VASP POSCAR, XYZ, Quantum ESPRESSO input, and more) utilizing the adapters from the Python [`optimade`](https://pypi.org/project/optimade/){:target=_blank} package in the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools){:target=_blank} repository.
 
 The filtering can be done either using the OPTIMADE filter language (see the specification for more information) directly, or one can use the friendly filtering widgets (default).

--- a/index.md
+++ b/index.md
@@ -27,6 +27,7 @@ existing and hypothetical materials, many of which have appeared online:
 - [the Joint Automated Repository for Various Integrated Simulations](https://jarvis.nist.gov)
 - ...
 
-Should you wish to cite the OPTIMADE specification, please use
+Should you wish to cite the OPTIMADE specification, please use the following:
 
-> Andersen *et al*, The OPTIMADE Specification, [10.5281/zenodo.4195050](https://doi.org/10.5281/zenodo.4195050)
+- Andersen *et al*, OPTIMADE: an API for exchanging materials data (2021) [arXiv:2103.02068](https://arxiv.org/abs/2103.02068){:target=_blank}
+- Andersen *et al*, The OPTIMADE Specification, [10.5281/zenodo.4195050](https://doi.org/10.5281/zenodo.4195050){:target=blank}


### PR DESCRIPTION
The clients page showcases the various available clients to query OPTIMADE databases.

There are currently 3 different clients:
- Swagger/OpenAPI UI (petstore.swagger.io)
- MaterialsCloud Tool (materialscloud.org/optimadeclient)
- optimade.science

To access this new page, a new menu item "Try It!" has been added.

I have requested reviews from the "management", providers I have explicitly mentioned, and client creators, and would especially like all entities who are mentioned on the new page to give their consent.