### PR TITLE
Quick pass on the index page, add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @rartino @gmrigna @CasperWA @ml-evs @shyam
+_includes/next_meeting.html @ml-evs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rartino @gmrigna @CasperWA @ml-evs @shyam

--- a/_includes/next_meeting.html
+++ b/_includes/next_meeting.html
@@ -1,0 +1,1 @@
+[Friday April 23rd at 15:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210420T15)

--- a/_includes/next_meeting.html
+++ b/_includes/next_meeting.html
@@ -1,1 +1,2 @@
-[Friday April 23rd at 15:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210420T15)
+[Friday April 23rd at 15:00
+UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210420T15){:target=_blank}

--- a/index.md
+++ b/index.md
@@ -48,7 +48,8 @@ join the discussion, please feel free to reach out on the mailing list
 The next meeting will take place on {% include {{ page.next_meeting }} %}.
 
 
-With the support of [CECAM](www.cecam.org){:target=_blank}, we hold annual
-workshops to discuss and develop the specification and related ideas.
+With the support of [CECAM](www.cecam.org){:target=_blank}, we hold 
+[annual workshops](https://www.cecam.org/search#stq=%22Open%20Databases%20Integration%20for%20Materials%20Design%22&stp=1)
+to discuss and develop the specification and related ideas.
 The 2021 workshop will be held virtually and the announcement will appear
 on the CECAM website soon.

--- a/index.md
+++ b/index.md
@@ -1,3 +1,8 @@
+---
+title: OPTIMADE
+next_meeting: next_meeting.html
+---
+
 # About us
 
 The **Open Databases Integration for Materials Design** (OPTIMADE) consortium
@@ -40,8 +45,8 @@ implementations and hear your feedback on the specification.
 We meet monthly in the "OPTIMADE" room on Jitsi; everyone is welcome to
 join the discussion, please feel free to reach out on the mailing list
 `dev[at]optimade.org` to register your interest.
-The next meeting will take place on
-[Friday April 23rd at 15:00 UTC](https://www.worldtimebuddy.com/?pl=1&lid=2643743,5128581,5391959,2950159&h=2643743&date=4/23/2021%7C3&hf=1){:target=_blank}.
+The next meeting will take place on {% include {{ page.next_meeting }} %}.
+
 
 With the support of [CECAM](www.cecam.org){:target=_blank}, we hold annual
 workshops to discuss and develop the specification and related ideas.

--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ The next meeting will take place on {% include {{ page.next_meeting }} %}.
 
 
 With the support of [CECAM](www.cecam.org){:target=_blank}, we hold 
-[annual workshops](https://www.cecam.org/search#stq=%22Open%20Databases%20Integration%20for%20Materials%20Design%22&stp=1)
+[annual workshops](https://www.cecam.org/search#stq=%22Open%20Databases%20Integration%20for%20Materials%20Design%22&stp=1){:target=_blank}
 to discuss and develop the specification and related ideas.
 The 2021 workshop will be held virtually and the announcement will appear
 on the CECAM website soon.

--- a/index.md
+++ b/index.md
@@ -1,7 +1,10 @@
 # About us
 
 The **Open Databases Integration for Materials Design** (OPTIMADE) consortium
-aims to make materials databases interoperational by developing a common REST API.
+aims to make materials databases interoperable by developing a specification
+for a common REST API.
+
+## Motivation
 
 Designing new materials suitable for specific applications is a long,
 complex, and costly process. Researchers think of new ideas based on
@@ -13,21 +16,34 @@ electronic structure codes, it has become possible to perform large sets
 of calculations automatically. This is the burgeoning area of
 high-throughput ab initio computation. Such calculations have been used
 to create large databases containing the calculated properties of
-existing and hypothetical materials, many of which have appeared online:
+existing and hypothetical materials, many of which have appeared online.
 
-- [the AFLOW distributed materials property repository](http://aflowlib.org/)
-- [the Harvard Clean Energy Project Database](http://molecularspace.org/)
-- [the Materials Cloud](http://materialscloud.org/)
-- [the Materials Project](http://materialsproject.org/)
-- [the NoMaD (Novel Materials Discovery) Repository](http://nomad-repository.eu/)
-- [the Open Quantum Materials Database](http://oqmd.org/)
-- [the Computational Materials Repository](http://cmr.fysik.dtu.dk/)
-- [the Data Catalyst Genome](http://suncat.stanford.edu/)
-- [the Materials Platform for Data Science](http://mpds.io/)
-- [the Joint Automated Repository for Various Integrated Simulations](https://jarvis.nist.gov)
-- ...
+We have released version 1.0 of the OPTIMADE specification, with several
+databases already providing implementations. A full list is available on
+the [OPTIMADE providers dashboard](https://www.optimade.org/providers-dashboard/).
+
+## How to cite OPTIMADE
 
 Should you wish to cite the OPTIMADE specification, please use the following:
 
 - Andersen *et al*, OPTIMADE: an API for exchanging materials data (2021) [arXiv:2103.02068](https://arxiv.org/abs/2103.02068){:target=_blank}
-- Andersen *et al*, The OPTIMADE Specification, [10.5281/zenodo.4195050](https://doi.org/10.5281/zenodo.4195050){:target=blank}
+- Andersen *et al*, The OPTIMADE Specification, [10.5281/zenodo.4195050](https://doi.org/10.5281/zenodo.4195050){:target=_blank}
+
+## Get involved
+
+All of our work is openly available under the
+[Materials-Consortia](https://github.com/Materials-Consortia/) organization on
+GitHub and welcome all contributions.
+
+We would love to help you create and register your own OPTIMADE API
+implementations and hear your feedback on the specification.
+We meet monthly in the "OPTIMADE" room on Jitsi; everyone is welcome to
+join the discussion, please feel free to reach out on the mailing list
+`dev[at]optimade.org` to register your interest.
+The next meeting will take place on
+[Friday April 23rd at 15:00 UTC](https://www.worldtimebuddy.com/?pl=1&lid=2643743,5128581,5391959,2950159&h=2643743&date=4/23/2021%7C3&hf=1){:target=_blank}.
+
+With the support of [CECAM](www.cecam.org){:target=_blank}, we hold annual
+workshops to discuss and develop the specification and related ideas.
+The 2021 workshop will be held virtually and the announcement will appear
+on the CECAM website soon.


### PR DESCRIPTION
This PR refactors the index page of the website:

- [x] Remove random list of (previously) online databases
- [x] Add mention of providers dashboard
- [x] Add "Get Involved" section
    - [x] Advertise meetings
    - [x] Advertise workshop  
    - [x] Advertise mailing list
    - [x] Advertise 
- [x] Add a bunch of random people to CODEOWNERS so they get automatic review requests

This PR does not: 
- improve the wording of the intro paragraph that describes what OPTIMADE is, potentially separating the motivation section to a new page as suggested at #9. It would be good if this could be added to the README of the specification too.