### PR TITLE
Add link checker to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: master
+  schedule:
+    # Run at 4:08am every Monday
+    - cron: "8 4 * * 1"
+
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v1
+    - name: Link Checker
+      id: lychee
+      uses: lycheeverse/lychee-action@v1.0.8
+      with:
+        args: --verbose --no-progress **/*.md **/*.html
+
+    - name: Fail on link errors in PRs
+      if: ${{ github.event_name == 'pull_request' }}
+      run: exit ${{ steps.lychee.outputs.exit_code }}
+
+    - name: Create Issue
+      if: ${{ github.event_name == 'schedule' }}
+      uses: peter-evans/create-issue-from-file@v2
+      with:
+        title: Dead links detected
+        content-filepath: ./lychee/out.md
+        labels: 'link rot'


### PR DESCRIPTION
Once a week, this will check that the links we have added to the website are still alive (and also on pull requests).

It has already picked up two broken links for materialscloud. I suggest we merge this PR with the broken links in order to test that issues are raised on push.