### PR TITLE
Links should go via www.optimade.org, not the forwarding URL optimade.org

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -3,5 +3,5 @@
 - [Current stable API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/master/schemas/openapi_schema.json){:target="_blank"}
 - [Development API Specification (Swagger/OpenAPI)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Materials-Consortia/OPTIMADE/develop/schemas/openapi_schema.json){:target="_blank"}
 - [OPTIMADE wiki on GitHub](https://github.com/Materials-Consortia/OPTIMADE/wiki){:target="_blank"}
-- [`optimade-python-tools` documentation](https://optimade.org/optimade-python-tools){:target="_blank"}
+- [`optimade-python-tools` documentation](https://www.optimade.org/optimade-python-tools){:target="_blank"}
 - [`optimade-tutorial-exercises`](https://github.com/Materials-Consortia/optimade-tutorial-exercises): An open-ended set of exercises initially prepared for the NOMAD Virtual Tutorial Series.


### PR DESCRIPTION
This was detected because the SSL cert for optimade.org is down. However, since we decided www.optimade.org is the main URL (and optimade.org is just a forward), it is better to let links include the 'www'.