### PR TITLE
Link to GitHub topic instead of GitHub org

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
                 <a href="documentation">Documentation</a>
                 <a href="optimade">Specification</a>
                 <a href="contributors">Contributors</a>
-                <a href="https://github.com/Materials-Consortia/" target="_blank">GitHub</a>
+                <a href="https://github.com/topics/optimade" target="_blank">GitHub</a>
                 <a href="https://matsci.org/c/optimade/" target="_blank">Forum</a>
                 <span class="special_menu"><a href="clients">Try It!</a></span>
        	    </div>


### PR DESCRIPTION
GitHub topic [*optimade*](https://github.com/topics/optimade) (i.e. those links at the right box of any repository) includes more projects, than the official org.

Of course, *Materials-Consortia* org repos are included.

Also adding an _optimade_ topic to an existing repo (if it's missing) is just a couple of mouse clicks.